### PR TITLE
Fix: Correct CSS classes for project images

### DIFF
--- a/_includes/research-projects.html
+++ b/_includes/research-projects.html
@@ -3,8 +3,8 @@
   <div class="projects-grid">
     {% for project in site.data.projects limit:3 %}
     <div class="project-card">
-      <div class="project-card__image">
-        <img src="{{ project.image | default: '/assets/images/projects/default-project.jpg' }}" alt="{{ project.title }}">
+      <div class="project-image-container">
+        <img src="{{ project.image | default: '/assets/images/projects/default-project.jpg' }}" alt="{{ project.title }}" class="project-image">
       </div>
       <div class="project-card__content">
         <h3 class="project-title">{{ project.title }}</h3>


### PR DESCRIPTION
Updated `_includes/research-projects.html` to use the correct CSS class names for project image containers and images themselves.
- Changed `project-card__image` to `project-image-container`.
- Added `project-image` class to `<img>` tags. This ensures that styles for image dimensions, object-fit, and hover effects are correctly applied, resolving an issue where project images might not have been displaying as intended on the homepage.