### PR TITLE
Feat: Move #toread section higher on homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,10 @@ title: Home
     {% include research-projects.html %}
   </div>
 
+  <div class="animate-on-scroll mt-xl">
+    {% include toread-papers.html %}
+  </div>
+
   <div class="grid grid-col-2 gap-lg mt-xl">
     <section class="news animate-on-scroll">
       <h2 class="section-title">News & Updates</h2>
@@ -51,10 +55,6 @@ title: Home
         <i class="fas fa-circle-notch fa-spin"></i> Loading GitHub activity...
       </div>
     </section>
-  </div>
-  
-  <div class="animate-on-scroll mt-xl">
-    {% include toread-papers.html %}
   </div>
   
   <div class="animate-on-scroll mt-xl">


### PR DESCRIPTION
Moves the 'FG's #toread' section one conceptual row up on the homepage. The section is now positioned immediately after 'Research Projects' and before the 'News & Updates' / 'GitHub Activity' grid.

This change was made by reordering the include directive for `toread-papers.html` within the `index.html` file.